### PR TITLE
Fix draft previews

### DIFF
--- a/lib/api.js
+++ b/lib/api.js
@@ -26,17 +26,19 @@ const serializePosts = (posts) =>
       }),
       ...(p.help_tags && {
         tag_ids: p.help_tags,
-        tags: p._embedded?.['wp:term']?.[0]?.map((tag) => ({
-          ...tag,
-          link: `/tag/${tag.slug}`,
-        })),
+        tags:
+          p._embedded?.['wp:term']?.[0]?.map((tag) => ({
+            ...tag,
+            link: `/tag/${tag.slug}`,
+          })) || null,
       }),
       ...(p.help_tools && {
         tool_ids: p.help_tools,
-        tools: p._embedded?.['wp:term']?.[1]?.map((tool) => ({
-          ...tool,
-          link: `/${tool.slug}`,
-        })),
+        tools:
+          p._embedded?.['wp:term']?.[1]?.map((tool) => ({
+            ...tool,
+            link: `/${tool.slug}`,
+          })) || null,
       }),
       ...(p.categories && {
         category_ids: p.categories,

--- a/pages/additional-materials/[slug].js
+++ b/pages/additional-materials/[slug].js
@@ -15,7 +15,7 @@ export default function Article(props) {
 }
 
 export async function getStaticProps({ params, previewData, preview }) {
-  const isPreview = !!preview && previewData?.slug === params.slug;
+  const isPreview = !!preview;
   const article = await getPostByType({
     type: 'additional_materials',
     slug: params.slug,

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -4,6 +4,7 @@ const postTypePaths = {
   tools: '',
   articles: '/guides',
   webinars: '/webinars',
+  additional_materials: '/additional-materials',
 };
 
 // eslint-disable-next-line consistent-return

--- a/pages/api/preview.js
+++ b/pages/api/preview.js
@@ -56,7 +56,7 @@ export default async function preview(req, res) {
   res.writeHead(307, {
     Location: `/help${parentSlug ? `/${parentSlug}` : ''}${
       postTypePaths[post_type]
-    }/${post.slug}/`,
+    }/${post.id}/`,
   });
   res.end();
 }

--- a/pages/guides/[slug].js
+++ b/pages/guides/[slug].js
@@ -15,7 +15,7 @@ export default function Article(props) {
 }
 
 export async function getStaticProps({ params, previewData, preview }) {
-  const isPreview = !!preview && previewData?.slug === params.slug;
+  const isPreview = !!preview;
   const article = await getPostByType({
     type: 'articles',
     ...articlesFilter(isPreview, previewData),

--- a/pages/webinars/[slug].js
+++ b/pages/webinars/[slug].js
@@ -16,7 +16,7 @@ export default function Webinar(props) {
 }
 
 export async function getStaticProps({ params, preview, previewData }) {
-  const isPreview = !!preview && previewData?.slug === params.slug;
+  const isPreview = !!preview;
   const webinar = await getPostByType({
     type: 'webinars',
     slug: params.slug,


### PR DESCRIPTION
## Description

- Fix Failure to fetch custom post types  
- Add `additional-materials` post type as a preview-able post type
- Fix serialisation issues when `tags` or `tools` are `undefined`

## Tracking

[https://gfw.atlassian.net/browse/FLAG-624](FLAG-624)