### PR TITLE
Add simple lightbox to images for help center pages

### DIFF
--- a/components/content/index.js
+++ b/components/content/index.js
@@ -6,6 +6,7 @@ import { Carousel } from 'gfw-components';
 
 import Blockquote from 'components/blockquote';
 import CodeBlock from 'components/code-block';
+import Lightbox from 'components/lightbox';
 
 import ContentWrapper from './styles';
 
@@ -42,14 +43,10 @@ const PostContent = ({ children, align, print }) => (
           );
         }
 
-        if (print && node.name === 'img') {
-          return (
-            <img
-              key={node.attribs.href}
-              src={node.attribs.src}
-              alt={node.attribs.alt}
-            />
-          );
+        if (node.name === 'img') {
+          const { src, alt, key } = node?.attribs;
+          if (print) return <img src={src} alt={alt} key={key} />;
+          return <Lightbox src={src} alt={alt} key={key} />;
         }
 
         return '';

--- a/components/lightbox/index.js
+++ b/components/lightbox/index.js
@@ -1,0 +1,28 @@
+import React, { useState } from 'react';
+import PropTypes from 'prop-types';
+
+import { Image, Wrapper, Backdrop, LightboxImg } from './styles';
+
+const Lightbox = ({ src, alt, key }) => {
+  const [open, setOpen] = useState(false);
+  return (
+    <>
+      <Image src={src} alt={alt} key={key} onClick={() => setOpen(true)} />
+
+      {open && (
+        <Wrapper onClick={() => setOpen(false)}>
+          <Backdrop />
+          <LightboxImg src={src} alt={alt} key={key} />
+        </Wrapper>
+      )}
+    </>
+  );
+};
+
+Lightbox.propTypes = {
+  src: PropTypes.string,
+  alt: PropTypes.string,
+  key: PropTypes.string,
+};
+
+export default Lightbox;

--- a/components/lightbox/styles.js
+++ b/components/lightbox/styles.js
@@ -1,0 +1,35 @@
+import styled from '@emotion/styled';
+
+export const Image = styled.img`
+  cursor: pointer;
+`;
+
+export const Wrapper = styled.div`
+  cursor: zoom-out;
+  position: fixed;
+  z-index: 100;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+
+  display: flex;
+  justify-content: center;
+  justify-items: center;
+  padding: 2%;
+`;
+
+export const Backdrop = styled.span`
+  position: fixed;
+  left: 0;
+  right: 0;
+  top: 0;
+  bottom: 0;
+  background-color: #000;
+  opacity: 0.8;
+`;
+
+export const LightboxImg = styled.img`
+  position: relative;
+  object-fit: scale-down !important;
+`;


### PR DESCRIPTION
## Description

This PR adds a simple Lightbox to the help center article pages, similar to the one here: https://mapbuilder.wri.org/tutorials/step1-create-web-map/

## Notes

Not due now due to time constraints, but if required, the lightbox itself could live in `gfw-components` in order to be usable for the blog as well. 

## Tracking  

[FLAG-650](https://gfw.atlassian.net/browse/FLAG-650)